### PR TITLE
Fix clean build not working after upgrade

### DIFF
--- a/Service/Service.fsproj
+++ b/Service/Service.fsproj
@@ -17,6 +17,7 @@
   <ItemGroup>
     <PackageReference Include="Giraffe" Version="6.0.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="Ply" Version="0.3.1" />
     <PackageReference Include="Thoth.Json.Giraffe" Version="5.0.0" />
     <PackageReference Update="FSharp.Core" Version="7.0.200" />
   </ItemGroup>


### PR DESCRIPTION
I messed up in the last PR, as I only checked with an existing build that everything works and not with a clean checkout.

Turns out that a clean build crashed when using the Thoth serializer, as for some reason the 'Ply' dependency is not loaded in. This PR fixes this by adding a direct reference, though we could consider filing an issue at the `Thoth.Json.Giraffe` package to ask them what is going on here.

I'll make sure to do a clean build next time.